### PR TITLE
fix: Avoid marking release as latest

### DIFF
--- a/.github/workflows/reusable_goreleaser.yml
+++ b/.github/workflows/reusable_goreleaser.yml
@@ -192,6 +192,7 @@ jobs:
         if: ${{ inputs.publish_gh }}
         with:
           preserve_order: true
+          make_latest: false
           files: |
             dist/*.deb
             dist/*.deb.sig


### PR DESCRIPTION
# Description
Release may be created manually, or artifacts may be re-published for a former release, the PR prevents of marking release latest to preserve the "latestness" when release was created.