### PR TITLE
fix: Add major/minor/patch to "prepare-release"

### DIFF
--- a/actions/prepare-release/action.yml
+++ b/actions/prepare-release/action.yml
@@ -38,6 +38,15 @@ outputs:
   new_release_version:
     description: "New release version"
     value: ${{ steps.semantic_release.outputs.new_release_version }}
+  new_release_major_version:
+    description: "New release major version"
+    value: ${{ steps.semantic_release.outputs.new_release_major_version }}
+  new_release_minor_version:
+    description: "New release minor version"
+    value: ${{ steps.semantic_release.outputs.new_release_minor_version }}
+  new_release_patch_version:
+    description: "New release patch version"
+    value: ${{ steps.semantic_release.outputs.new_release_patch_version }}
   new_release_notes:
     description: "New release changelog"
     value: ${{ steps.semantic_release.outputs.new_release_notes }}


### PR DESCRIPTION
# Description
Add major/minor/patch version numbers outputs to "prepare-release". May be used to force push major/minor version tags