### PR TITLE
fix: Add "git-note" for "Semantic Release"

### DIFF
--- a/actions/prepare-release/.releaserc.yaml.example
+++ b/actions/prepare-release/.releaserc.yaml.example
@@ -3,3 +3,8 @@ plugins:
     - preset: conventionalcommits
   - - "@semantic-release/release-notes-generator"
     - preset: conventionalcommits
+# For pre-release branches
+branches:
+  - main
+  - name: (alpha|beta|rc)
+    prerelease: true

--- a/actions/prepare-release/README.md
+++ b/actions/prepare-release/README.md
@@ -27,7 +27,7 @@ It is expected this action to be used with other actions to perform tag and rele
         id: prepare_release
         uses: elastiflow/gha-reusable/actions/prepare-release@v0
         with:
-          branch: "${{ github.ref_name }}"
+          add_git_notes: true
           changelog_update: true
           bump_version_yaml: true
           bump_version_yaml_path: galaxy.yml

--- a/actions/prepare-release/action.yml
+++ b/actions/prepare-release/action.yml
@@ -4,6 +4,9 @@ inputs:
   commit_back:
     default: "false"
     description: "Commit and push version updates"
+  add_git_notes:
+    default: "false"
+    description: "Add and push \"semantic-release\" git notes to determine release channel. Should be `true` if release is going to be done"
   changelog_update:
     default: "false"
     description: "Update changelog"
@@ -103,7 +106,7 @@ runs:
           doc: Update version/changelog
     # Git notes are needed for "semantic-release" to properly detect release channel
     - name: Add git notes
-      if: ${{ fromJson(steps.semantic_release.outputs.new_release_published) }}
+      if: ${{ fromJson(steps.semantic_release.outputs.new_release_published) && fromJson(inputs.add_git_notes)}}
       shell: bash
       run: |
         git config --global user.email "github-actions[bot]@users.noreply.github.com"

--- a/actions/prepare-release/action.yml
+++ b/actions/prepare-release/action.yml
@@ -1,9 +1,6 @@
 name: 'Prepare release'
 description: 'Update manifests, changelog before the release'
 inputs:
-  branch:
-    required: true
-    description: "Release branch"
   commit_back:
     default: "false"
     description: "Commit and push version updates"
@@ -72,10 +69,6 @@ runs:
         ci: false
         dry_run: true
         unset_gha_env: true
-        branches: |
-          [
-            '${{ inputs.branch }}'
-          ]
         extra_plugins: |
           conventional-changelog-conventionalcommits
     - name: Bump version in YAML

--- a/actions/prepare-release/action.yml
+++ b/actions/prepare-release/action.yml
@@ -101,3 +101,12 @@ runs:
       with:
         commit_message: |
           doc: Update version/changelog
+    # Git notes are needed for "semantic-release" to properly detect release channel
+    - name: Add git notes
+      if: ${{ fromJson(steps.semantic_release.outputs.new_release_published) }}
+      shell: bash
+      run: |
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+        git config --global user.name "github-actions[bot]"
+        git notes --ref semantic-release add -f -m '{"channels":["${{ steps.semantic_release.outputs.new_release_channel }}"]}'
+        git push origin refs/notes/semantic-release


### PR DESCRIPTION
# Description
"Semantic Release" uses git notes in `semantic-release` ref to determin the release channel. 
`git-notes` should be added only when the actual release is planned to occur.

Inspired by [doc](https://semantic-release.gitbook.io/semantic-release/support/troubleshooting#release-not-found-release-branch-after-git-push-force).

Additionally remove `branch` input. By default the [default](https://semantic-release.gitbook.io/semantic-release/usage/configuration#branches) config is used, which can be overridden on repo basis.