### PR TITLE
feat: Ability to specify "tag_format" for pre-release action.

### DIFF
--- a/actions/prepare-release/action.yml
+++ b/actions/prepare-release/action.yml
@@ -1,6 +1,10 @@
 name: 'Prepare release'
 description: 'Update manifests, changelog before the release'
 inputs:
+  semantic_release_tag_format:
+    required: false
+    description: |
+      The semantic-release tag format, like "v${version}" or "someapp-${version}
   commit_back:
     default: "false"
     description: "Commit and push version updates"
@@ -66,10 +70,11 @@ runs:
   steps:
     - name: Semantic Release
       id: semantic_release
-      uses: cycjimmy/semantic-release-action@16ca923e6ccbb50770c415a0ccd43709a8c5f7a4 # v4.2.2
+      uses: cycjimmy/semantic-release-action@9cc899c47e6841430bbaedb43de1560a568dfd16 # v5.0.0
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
       with:
+        tag_format: ${{ inputs.semantic_release_tag_format }}
         ci: false
         dry_run: true
         unset_gha_env: true


### PR DESCRIPTION
# Description
In some cases we may need to set [tag_format](https://semantic-release.gitbook.io/semantic-release/usage/configuration#tagformat) for the "semantic-release", for example to have an app name as the tag prefix for the helm chart release. 
Although `tag_format` may be defined in the config, it does not work very well for the monorepo, when multiple configs may be needed for multiple apps, which has some issues - [ref](https://github.com/semantic-release/semantic-release/issues/1592#issuecomment-1695740555). Moreover, the underlying action we use always tries to download the config from NPM instead of using a local file.