### PR TITLE
feat(prepare-release): Add monorepo support

### DIFF
--- a/actions/prepare-release/README.md
+++ b/actions/prepare-release/README.md
@@ -45,8 +45,36 @@ It is expected this action to be used with other actions to perform tag and rele
         with:
           tag_name: v${{ steps.prepare_release.outputs.new_release_version }}
           body: ${{ steps.prepare_release.outputs.new_release_notes }}
+          target_commitish: ${{ github.ref_name }}
           preserve_order: true
           make_latest: true
 ```
 
 Please see the action manifest `inputs`/`outputs` for the config details.
+
+## "git notes"
+
+The action can add [git notes](https://git-scm.com/docs/git-notes) which are required for the "semantic-release" to properly detect a release channel.
+It makes sense to add "git notes" to the commits on a release/pre-release branches only, so action will add "git notes" (if enabled) to the `HEAD` commit on the current branch, e.g. if release is happening from `main`, release notes are added to the `HEAD` commit from `main` branch.
+
+## Monorepo support (experimental)
+
+This action may be used with monorepos, provided the directory structure is properly configured. To enable monorepo support:
+
+- Add [semantic-release-monorepo](https://github.com/pmowrer/semantic-release-monorepo) to your `.releaserc.yaml` configuration.
+- Place the `.releaserc.yaml` to a separate directory (application directory in the monorepo)
+- Specify the `semantic_release_working_directory` and `semantic_release_monorepo` inputs in the action.
+
+Example configuration:
+
+```yaml
+plugins:
+  - - "@semantic-release/commit-analyzer"
+    - preset: conventionalcommits
+  - - "@semantic-release/release-notes-generator"
+    - preset: conventionalcommits
+extends: semantic-release-monorepo
+tagFormat: awesomeApp-${version}
+```
+
+When using a monorepo, only changes within the specified `semantic_release_working_directory` are considered for versioning and changelog generation. This ensures releases are scoped to the relevant package or component within the repository.

--- a/actions/prepare-release/action.yml
+++ b/actions/prepare-release/action.yml
@@ -5,6 +5,15 @@ inputs:
     required: false
     description: |
       The semantic-release tag format, like "v${version}" or "someapp-${version}
+  semantic_release_working_directory:
+    required: false
+    description: |
+      The semantic-release working directory
+  semantic_release_monorepo:
+    default: "false"
+    description: |
+      Install the semantic-release semantic-release-monorepo plugin
+      Most likely you would want to set the "semantic_release_working_directory"
   commit_back:
     default: "false"
     description: "Commit and push version updates"
@@ -68,6 +77,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Install semantic-release-monorepo
+      if: ${{ fromJson(inputs.semantic_release_monorepo) }}
+      shell: bash
+      run: |
+        npm install -D semantic-release-monorepo@8.0.2 conventional-changelog-conventionalcommits
+      working-directory: ${{ inputs.semantic_release_working_directory }}
     - name: Semantic Release
       id: semantic_release
       uses: cycjimmy/semantic-release-action@9cc899c47e6841430bbaedb43de1560a568dfd16 # v5.0.0
@@ -75,6 +90,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github_token }}
       with:
         tag_format: ${{ inputs.semantic_release_tag_format }}
+        working_directory: ${{ inputs.semantic_release_working_directory }}
         ci: false
         dry_run: true
         unset_gha_env: true
@@ -119,3 +135,9 @@ runs:
         git config --global user.name "github-actions[bot]"
         git notes --ref semantic-release add -f -m '{"channels":["${{ steps.semantic_release.outputs.new_release_channel }}"]}'
         git push origin refs/notes/semantic-release
+    - name: Cleanup semantic-release-monorepo
+      if: ${{ fromJson(inputs.semantic_release_monorepo) }}
+      shell: bash
+      run: |
+        rm -rf package-lock.json package.json node_modules
+      working-directory: ${{ inputs.semantic_release_working_directory }}


### PR DESCRIPTION
# Description
Add a monorepo support to the `prepare-release` action. The feature relies on the [semantic-release-monorepo](https://github.com/pmowrer/semantic-release-monorepo) library and allows to have separate changelogs for different applications in the monorepo.

Note, the feature is still experimental and needs more "battle-testing"