### PR TITLE
feat: Add `outputs` param to `docker/build-push-action`

### DIFF
--- a/actions/docker-build-push/action.yml
+++ b/actions/docker-build-push/action.yml
@@ -110,7 +110,7 @@ runs:
       with:
         subject-name: ${{ inputs.registry }}/${{ inputs.image}}
         subject-digest: ${{ steps.build_push.outputs.digest }}
-        push-to-registry: ${{ fromJson(inputs.push) }}
+        push-to-registry: ${{ fromJson(inputs.push) || fromJson(inputs.push_attestation) }}
 
 outputs:
   digest:

--- a/actions/docker-build-push/action.yml
+++ b/actions/docker-build-push/action.yml
@@ -34,6 +34,15 @@ inputs:
   push:
     default: "false"
     description: "Push the image to registry or not, useful for cache-only builds"
+  push_attestation:
+    default: "false"
+    description: "Push the generated attestation to GHA"
+  outputs:
+    default: ""
+    description: |
+      Docker buildx outputs, https://docs.docker.com/reference/cli/docker/buildx/build/#output
+      Useful for multi-arch builds on separate runners:
+        push-by-digest=true,type=image,push=true
   cache_from:
     description: "Use docker cache from GHA Cache, https://docs.docker.com/reference/cli/docker/buildx/build/#cache-from"
   cache_to:
@@ -50,11 +59,18 @@ inputs:
   registry_password:
     description: "Docker registry password (token) to authenticate with, uses https://github.com/docker/login-action?tab=readme-ov-file#about"
 
+
 runs:
   using: "composite"
   steps:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+    # Enable containerd image store to allow loading manifest lists to the daemon
+    - name: Enable containerd image store
+      shell: bash
+      run: |
+        echo '{"features": {"containerd-snapshotter": true}}' | sudo tee /etc/docker/daemon.json
+        sudo systemctl restart docker
     - name: Log in to the Container registry
       if: ${{ fromJson(inputs.push) }}
       uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
@@ -69,12 +85,13 @@ runs:
       with:
         images: ${{ inputs.registry }}/${{ inputs.image }}
     - name: Build and push Docker image
-      id: push
+      id: build_push
       uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
       with:
         file: ${{ inputs.dockerfile }}
         platforms: ${{ inputs.platforms }}
-        tags: ${{ inputs.registry }}/${{ inputs.image }}:${{ inputs.tag }}
+        # Conditionally add tag if non-empty, needed for the case when `outputs: push-by-digest=true,type=image,push=true`
+        tags: "${{ inputs.registry }}/${{ inputs.image }}${{ case(inputs.tag != '', ':', '') }}${{ inputs.tag }}"
         build-args: |
             ${{ inputs.build_args }}
         target: ${{ inputs.target }}
@@ -83,13 +100,22 @@ runs:
         cache-to: ${{ inputs.cache_to }}
         load: ${{ fromJson(inputs.load) }}
         push: ${{ fromJson(inputs.push) }}
+        outputs: ${{ inputs.outputs }}
         provenance: ${{ inputs.provenance }}
         sbom: ${{ fromJson(inputs.sbom) }}
         labels: ${{ steps.meta.outputs.labels }}
     - name: Generate artifact attestation
       uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-      if: ${{ fromJson(inputs.push) }}
+      if: ${{ fromJson(inputs.push) || fromJson(inputs.push_attestation) }}
       with:
         subject-name: ${{ inputs.registry }}/${{ inputs.image}}
-        subject-digest: ${{ steps.push.outputs.digest }}
+        subject-digest: ${{ steps.build_push.outputs.digest }}
         push-to-registry: ${{ fromJson(inputs.push) }}
+
+outputs:
+  digest:
+    value: ${{ steps.build_push.outputs.digest }}
+    description: "Digest of the built image, example: sha256:abc123..."
+  metadata:
+    value: ${{ steps.build_push.outputs.metadata }}
+    description: "Build result metadata"


### PR DESCRIPTION
# Description
Introduce the `outputs` parameter to the `docker/build-push-action`. This enables the use of `--output=push-by-digest=true,type=image,push=true`, which is required for leveraging different runners to build multi-arch images.
Note: When using this approach, no tag should be defined, only `${registry}/${image}.

The flow is relatively simple:

```sh
# On x86_64 builder
docker build --platform linux/amd64 -t repo/image --output='push-by-digest=true,type=image,push=true'
# On AArch64 builder
docker build --platform linux/arm64 -t repo/image --output='push-by-digest=true,type=image,push=true'

# On any builder
docker buildx imagetools create \
  -t $repo/image:tag \
  repo/image@${SHA_x86_64_ARCH} \
  repo/image@${SHA_AArch64_ARCH}
```

Contributes to the https://github.com/elastiflow/mermin/issues/544 issue