### PR TITLE
feat: Add "Update GitOps" composite action

### DIFF
--- a/actions/update-gitops/README.md
+++ b/actions/update-gitops/README.md
@@ -1,0 +1,49 @@
+# update-gitops
+
+Composite GitHub Action that syncs manifest files into a GitOps branch and bumps a version key in YAML files.
+
+## What it does
+
+1. Detects (or accepts) the default branch.
+2. Checks out the GitOps branch.
+3. Copies the specified manifest file(s) from the default branch into the GitOps branch.
+4. Updates a version key in one or more YAML files using the short commit SHA.
+5. Commits and optionally pushes the changes.
+6. Adds the GHA status with new commit and diff
+
+## Usage
+
+```yaml
+- name: Update GitOps
+  uses: elastiflow/gha-reusable/actions/update-gitops@v0
+  with:
+    manifests_path: deploy/foobar/k8s,deploy/foobar/config.hcl
+    bump_version_yaml_path: deploy/foobar/k8s/values.yaml
+    bump_version_yaml_key: .image.tag
+    github_token: "${{ secrets.GITHUB_TOKEN }}"
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+| --- | --- | --- | --- |
+| `manifests_path` | yes | — | Comma-separated paths to manifest files to sync from the default branch |
+| `gitops_branch` | no | `gitops` | Target GitOps branch |
+| `default_branch` | no | `""` | Source branch to sync from |
+| `docker_tag_prefix` | no | `commit_` | Prefix prepended to the commit SHA when writing the image tag |
+| `bump_version_yaml_path` | yes | — | Comma-separated paths to YAML files to update |
+| `bump_version_yaml_key` | yes | — | [yq](https://mikefarah.gitbook.io/yq)-style key path to update |
+| `git_config_email` | no | `devops@elastiflow.com` | Git config email |
+| `git_config_user_name` | no | `DevOps Elastiflow` | Git config user name |
+| `push` | no | `false` | Set `"true"` to commit and push changes to the GitOps branch |
+| `github_token` | no | — | Token with write access; required when `push` is `true` |
+
+## Outputs
+
+| Output | Description |
+| --- | --- |
+| `new_commit_sha` | Short SHA of the default branch commit used for the update |
+
+## Requirements
+
+- [`yq`](https://mikefarah.gitbook.io/yq) must be available on the runner.

--- a/actions/update-gitops/action.yml
+++ b/actions/update-gitops/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: true
     description: |
       Version key in the YAML file, in the [yq](https://mikefarah.gitbook.io/yq) format.
-      Coma-separated list of keys are supported (no spaces)
+      Comma-separated list of keys are supported (no spaces)
   git_config_email:
     default: "devops@elastiflow.com"
     description: "Git config email"

--- a/actions/update-gitops/action.yml
+++ b/actions/update-gitops/action.yml
@@ -106,6 +106,7 @@ runs:
         echo "Committing changes"
         git add ./
 
+        echo "diff_present=$(git diff-index --quiet HEAD; echo $?)"
         echo "diff_present=$(git diff-index --quiet HEAD; echo $?)" >> $GITHUB_STEP_SUMMARY
         git diff-index --quiet HEAD || git commit -m "[auto] ${COMMIT_MESSAGE_HEADER}"
     # - name: Push changes

--- a/actions/update-gitops/action.yml
+++ b/actions/update-gitops/action.yml
@@ -106,12 +106,10 @@ runs:
         echo "Committing changes"
         git add ./
 
-        echo "diff_present=$(git diff-index --quiet HEAD; echo $?)"
-        echo "diff_present=$(git diff-index --quiet HEAD; echo $?)" >> $GITHUB_STEP_SUMMARY
+        echo "diff_present=$(git diff-index --quiet HEAD; echo $?)" >> $GITHUB_OUTPUT
         git diff-index --quiet HEAD || git commit -m "[auto] ${COMMIT_MESSAGE_HEADER}"
-    # - name: Push changes
     - name: Push changes
-      if: ${{ fromJson(inputs.push) && fromJson(steps.commit.outputs.committed) == 1 }}
+      if: ${{ fromJson(inputs.push) && fromJson(steps.commit.outputs.diff_present) == 1 }}
       shell: bash
       env:
         GITOPS_BRANCH: ${{ inputs.gitops_branch }}
@@ -128,12 +126,18 @@ runs:
       run: |
         echo "Setting GitHub Actions summary"
 
-        echo "GitOps branch \`${GITOPS_BRANCH}\` has been updated with the latest changes from \`origin/${DEFAULT_BRANCH}\`." >> $GITHUB_STEP_SUMMARY
-        echo "- New commit SHA: \`${COMMIT_SHA}\`" >> $GITHUB_STEP_SUMMARY
-        echo "- New docker tag: \`${DOCKER_TAG_PREFIX}${COMMIT_SHA}\`" >> $GITHUB_STEP_SUMMARY
+        if [ `git log -5 --format=%H | wc -l` -gt 1 ]; then
+          echo "GitOps branch \`${GITOPS_BRANCH}\` has been updated with the latest changes from \`origin/${DEFAULT_BRANCH}\`." >> $GITHUB_STEP_SUMMARY
+          echo "- New commit SHA: \`${COMMIT_SHA}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- New docker tag: \`${DOCKER_TAG_PREFIX}${COMMIT_SHA}\`" >> $GITHUB_STEP_SUMMARY
 
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "Diff with previous version:" >> $GITHUB_STEP_SUMMARY
-        echo '```diff'  >> $GITHUB_STEP_SUMMARY
-        git diff "HEAD~1" "HEAD" -- >> $GITHUB_STEP_SUMMARY
-        echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Diff with previous revision:" >> $GITHUB_STEP_SUMMARY
+          echo '```diff'  >> $GITHUB_STEP_SUMMARY
+          git diff "HEAD~1" "HEAD" -- >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+        else
+          echo "GitOps branch \`${GITOPS_BRANCH}\` is already up to date
+          echo "- Commit SHA: \`${COMMIT_SHA}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Docker tag: \`${DOCKER_TAG_PREFIX}${COMMIT_SHA}\`" >> $GITHUB_STEP_SUMMARY
+        fi

--- a/actions/update-gitops/action.yml
+++ b/actions/update-gitops/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: "Docker tag prefix to use in the manifests update, e.g. if commit SHA is used as a tag, then `commit_` can be used as a prefix"
   manifests_path:
     required: true
-    description: "Path to the manifests to update. Coma-separated list of paths are supported (no spaces)"
+    description: "Path to the manifests to update. Comma-separated list of paths are supported (no spaces)"
   bump_version_yaml_path:
     required: true
     description: |

--- a/actions/update-gitops/action.yml
+++ b/actions/update-gitops/action.yml
@@ -1,0 +1,138 @@
+name: 'Update GitOps'
+description: 'Update manifests in the GitOps branch'
+inputs:
+  default_branch:
+    default: ""
+    description: "Default branch to update from, e.g. main. If not set (empty string), it will be determined automatically."
+  gitops_branch:
+    default: "gitops"
+    description: "GitOps branch to update"
+  docker_tag_prefix:
+    default: "commit_"
+    description: "Docker tag prefix to use in the manifests update, e.g. if commit SHA is used as a tag, then `commit_` can be used as a prefix"
+  manifests_path:
+    required: true
+    description: "Path to the manifests to update. Coma-separated list of paths are supported (no spaces)"
+  bump_version_yaml_path:
+    required: true
+    description: |
+      Path to the YAML where version should be bumped
+      Coma-separated list of files are supported (no spaces)
+  bump_version_yaml_key:
+    required: true
+    description: |
+      Version key in the YAML file, in the [yq](https://mikefarah.gitbook.io/yq) format.
+      Coma-separated list of keys are supported (no spaces)
+  git_config_email:
+    default: "devops@elastiflow.com"
+    description: "Git config email"
+  git_config_user_name:
+    default: "DevOps Elastiflow"
+    description: "Git config user name"
+  push:
+    default: "false"
+    description: "Update changelog"
+  github_token:
+    required: false
+    description: "GitHub token with write permissions to the repo, required if `push` is true"
+outputs:
+  new_commit_sha:
+    description: "New commit SHA after updating GitOps"
+    value: ${{ steps.set_attrs.outputs.commit_sha_short }}
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Configure git
+      shell: bash
+      env:
+        GIT_CONFIG_EMAIL: ${{ inputs.git_config_email }}
+        GIT_CONFIG_USER_NAME: ${{ inputs.git_config_user_name }}
+      run: |
+        git config --global user.email "${GIT_CONFIG_EMAIL}"
+        git config --global user.name "${GIT_CONFIG_USER_NAME}"
+    - name: Set default branch
+      id: set_default_branch
+      shell: bash
+      run: |
+        echo "Setting default branch"
+        echo "default_branch=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')" >> $GITHUB_OUTPUT
+    - name: Set attrs
+      id: set_attrs
+      shell: bash
+      env:
+        DEFAULT_BRANCH: ${{ case(inputs.default_branch == '', steps.set_default_branch.outputs.default_branch, inputs.default_branch) }}
+      run: |
+        echo "Setting attributes"
+        git fetch origin ${DEFAULT_BRANCH} --depth=1
+
+        echo "default_branch=${DEFAULT_BRANCH}" >> $GITHUB_OUTPUT
+        echo "commit_sha_short=$(git rev-parse --short origin/${DEFAULT_BRANCH})" >> $GITHUB_OUTPUT
+        echo "commit_message_header=$(git log -1 --pretty=%s origin/${DEFAULT_BRANCH})" >> $GITHUB_OUTPUT
+    - name: Checkout GitOps branch
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: ${{ inputs.gitops_branch }}
+    - name: Update manifests
+      shell: bash
+      env:
+        MANIFESTS_PATH: ${{ inputs.manifests_path }}
+        DEFAULT_BRANCH: ${{ steps.set_attrs.outputs.default_branch }}
+      run: |
+        echo "Update manifests from origin/${DEFAULT_BRANCH}"
+        git fetch origin ${DEFAULT_BRANCH} --depth=1
+        git checkout "origin/${DEFAULT_BRANCH}" -- $(echo ${MANIFESTS_PATH} | tr ',' ' ')
+    - name: Bump version in YAML
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        BUMP_VERSION_YAML_PATH: ${{ inputs.bump_version_yaml_path }}
+        BUMP_VERSION_YAML_KEY: ${{ inputs.bump_version_yaml_key }}
+        DOCKER_TAG_PREFIX: ${{ inputs.docker_tag_prefix }}
+        COMMIT_SHA: ${{ steps.set_attrs.outputs.commit_sha_short }}
+      run: |
+        echo 'Bump version in YAML'
+        sh "${ACTION_PATH}/bump_yaml.sh" \
+          "${BUMP_VERSION_YAML_PATH}" \
+          "${BUMP_VERSION_YAML_KEY}" \
+          "${DOCKER_TAG_PREFIX}${COMMIT_SHA}"
+    - name: Commit changes
+      shell: bash
+      id: commit
+      env:
+        COMMIT_MESSAGE_HEADER: ${{ steps.set_attrs.outputs.commit_message_header }}
+      run: |
+        echo "Committing changes"
+        git add ./
+
+        echo "diff_present=$(git diff-index --quiet HEAD; echo $?)" >> $GITHUB_STEP_SUMMARY
+        git diff-index --quiet HEAD || git commit -m "[auto] ${COMMIT_MESSAGE_HEADER}"
+    # - name: Push changes
+    - name: Push changes
+      if: ${{ fromJson(inputs.push) && fromJson(steps.commit.outputs.committed) == 1 }}
+      shell: bash
+      env:
+        GITOPS_BRANCH: ${{ inputs.gitops_branch }}
+      run: |
+        echo "Pushing changes"
+        git push origin ${GITOPS_BRANCH}
+    - name: Set GHA summary
+      shell: bash
+      env:
+        DEFAULT_BRANCH: ${{ steps.set_attrs.outputs.default_branch }}
+        GITOPS_BRANCH: ${{ inputs.gitops_branch }}
+        DOCKER_TAG_PREFIX: ${{ inputs.docker_tag_prefix }}
+        COMMIT_SHA: ${{ steps.set_attrs.outputs.commit_sha_short }}
+      run: |
+        echo "Setting GitHub Actions summary"
+
+        echo "GitOps branch \`${GITOPS_BRANCH}\` has been updated with the latest changes from \`origin/${DEFAULT_BRANCH}\`." >> $GITHUB_STEP_SUMMARY
+        echo "- New commit SHA: \`${COMMIT_SHA}\`" >> $GITHUB_STEP_SUMMARY
+        echo "- New docker tag: \`${DOCKER_TAG_PREFIX}${COMMIT_SHA}\`" >> $GITHUB_STEP_SUMMARY
+
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "Diff with previous version:" >> $GITHUB_STEP_SUMMARY
+        echo '```diff'  >> $GITHUB_STEP_SUMMARY
+        git diff "HEAD~1" "HEAD" -- >> $GITHUB_STEP_SUMMARY
+        echo '```' >> $GITHUB_STEP_SUMMARY

--- a/actions/update-gitops/action.yml
+++ b/actions/update-gitops/action.yml
@@ -137,7 +137,7 @@ runs:
           git diff "HEAD~1" "HEAD" -- >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
         else
-          echo "GitOps branch \`${GITOPS_BRANCH}\` is already up to date
+          echo "GitOps branch \`${GITOPS_BRANCH}\` is already up to date"  >> $GITHUB_STEP_SUMMARY
           echo "- Commit SHA: \`${COMMIT_SHA}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Docker tag: \`${DOCKER_TAG_PREFIX}${COMMIT_SHA}\`" >> $GITHUB_STEP_SUMMARY
         fi

--- a/actions/update-gitops/action.yml
+++ b/actions/update-gitops/action.yml
@@ -17,7 +17,7 @@ inputs:
     required: true
     description: |
       Path to the YAML where version should be bumped
-      Coma-separated list of files are supported (no spaces)
+      Comma-separated list of files are supported (no spaces)
   bump_version_yaml_key:
     required: true
     description: |

--- a/actions/update-gitops/bump_yaml.sh
+++ b/actions/update-gitops/bump_yaml.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -e
+
+yaml_path=$1
+yaml_key=$2
+new_release_version=$3
+
+if [ -z "${yaml_path}" ]; then echo "'yaml_path (\$1)' is not set, exiting"; exit 1; fi
+if [ -z "${yaml_key}" ]; then echo "'yaml_key (\$2)' is not set, exiting"; exit 1; fi
+if [ -z "${new_release_version}" ]; then echo "'new_release_version (\$3)' is not set, exiting"; exit 1; fi
+
+paths=$(echo $yaml_path | tr ',' '\n')
+keys=$(echo $yaml_key | tr ',' '\n')
+
+update_yaml_key() {
+	key=$2
+	path=$1
+
+	yq "${key} = \"${new_release_version}\"" "${path}" > /tmp/new.yaml
+	if grep -q "${new_release_version}" /tmp/new.yaml; then
+		echo 'Version update succeeded, new:'
+		grep "${new_release_version}" /tmp/new.yaml
+	else
+		echo 'Version update failed, exiting'
+		exit 1
+	fi
+
+	diff -U0 -w -b --ignore-blank-lines "${path}" /tmp/new.yaml > /tmp/version.diff || true
+	patch "${path}" < /tmp/version.diff
+}
+
+for p in ${paths}; do
+	for k in ${keys}; do
+		update_yaml_key ${p} ${k}
+	done
+done


### PR DESCRIPTION
# Description
Add "Update GitOps" composite action that will:
1. Detects (or accepts) the default branch.
2. Checks out the GitOps branch.
3. Copies the specified manifest file(s) from the default branch into the GitOps branch.
4. Updates a version key in one or more YAML files using the short commit SHA.
5. Commits and optionally pushes the changes.
6. Adds the GHA status with new commit and diff