### PR TITLE
fix: Docker auth before build

### DIFF
--- a/actions/docker-build-push/action.yml
+++ b/actions/docker-build-push/action.yml
@@ -72,7 +72,7 @@ runs:
         echo '{"features": {"containerd-snapshotter": true}}' | sudo tee /etc/docker/daemon.json
         sudo systemctl restart docker
     - name: Log in to the Container registry
-      if: ${{ fromJson(inputs.push) }}
+      if: ${{ (fromJson(inputs.push) || contains(inputs.outputs, 'push=true')) && inputs.registry_password }}
       uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
       with:
         registry: ${{ inputs.registry }}


### PR DESCRIPTION
# Description
"docker-build-push" composite action was not running the authentication fir `push` was `false` but `outputs` contained `push=true` preventing the action to authenticate to Docker registries when using "push-by-digest" approach