### PR TITLE
fix: Simplify the "PR checks" workflow

### DIFF
--- a/.github/workflows/reusable_pr_checks.yml
+++ b/.github/workflows/reusable_pr_checks.yml
@@ -14,14 +14,13 @@ jobs:
   pr_title_lint:
     name: 'pr-title-lint'
     runs-on: ${{ inputs.runs-on }}
+    container: oven/bun:1.3.14-alpine@sha256:5acc90a93e91ff07bf72aa90a7c9f0fa189765aec90b47bdbf2152d2196383c0
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - name: Install commitlint
-        run: npm install -D @commitlint/cli @commitlint/config-conventional
       - name: Validate PR commits with commitlint
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          echo "${PR_TITLE}" | npx commitlint --verbose
+          echo "${PR_TITLE}" | bunx commitlint --verbose


### PR DESCRIPTION
# Description
Simplify the "PR checks" workflow by using `bun` docker container and run commitlint via [bunx](https://bun.com/docs/pm/bunx) preventing potential issues related to `npm`/`npx` and modules overrides like
```
npm error Override for @types/react@^19.2.15 conflicts with direct dependency
```