### PR TITLE
fix: `commitlint` error

### DIFF
--- a/.github/workflows/reusable_pr_checks.yml
+++ b/.github/workflows/reusable_pr_checks.yml
@@ -19,8 +19,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Clean
+        run:  |
+          find . -mindepth 1 -maxdepth 1 -not -name '*commitlintrc*' -exec rm -rf {} \;
       - name: Validate PR commits with commitlint
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
+          bun install --dev @commitlint/config-conventional
           echo "${PR_TITLE}" | bunx commitlint --verbose


### PR DESCRIPTION
# Description
Changed how deps are defined, and following error started to occur
```
ResolveMessage: Cannot find package 'conventional-changelog-conventionalcommits' from '/github/home/.bun/install/cache/@commitlint/config-conventional@21.2.0@@@1/lib/noop.js'
      at <anonymous> (/tmp/bunx-0-commitlint@latest/node_modules/@commitlint/cli/lib/cli.js:142:15)
```

PR explicitly installs the commitlint configs